### PR TITLE
Fix error with `consul_to_upload_properties` variable between plays. with_dict need exists even skipped task .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 [Full Changelog](https://github.com/idealista/consul_keystore_role/compare/master...develop)
 
+- Fix error with `consul_to_upload_properties` variable between plays. with_dict need exists even skipped task @adrian-arapiles
 ## [2.0.1] 2022-03-04
 ### Fixed
 - *[#13](https://github.com/idealista/consul_keystore_role/issues/13) Fixed delete steps making diff of whole keys and files processed. @adrian-arapiles*

--- a/tasks/manage_keys_yml_file.yml
+++ b/tasks/manage_keys_yml_file.yml
@@ -7,6 +7,10 @@
   changed_when: false
   register: consul_check_yaml_file
 
+- name: Set consul_to_upload_properties empty to avoid error between plays
+  set_fact:
+    consul_to_upload_properties: {}
+
 - name: Consul | Manage keys from {{ consul_keystore_properties_path }}/{{ consul_keystore_properties_file }} KV
   block:
     - name: Read local properties


### PR DESCRIPTION
### Description of the Change
Fix error with `consul_to_upload_properties` variable between plays. with_dict need that variable exists even skipped task .

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

Be able to executed several files or times without error.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
